### PR TITLE
Feature/catch nullrefexception for empy glb file

### DIFF
--- a/Runtime/Scripts/GltfAsset.cs
+++ b/Runtime/Scripts/GltfAsset.cs
@@ -118,12 +118,12 @@ namespace GLTFast
                 try
                 {
                     // Automatic load on startup
-                    await Load(FullUrl);
+                    Error = !(await Load(FullUrl));
                 }
                 catch (NullReferenceException e)
                 {
                     Error = true;
-                    ErrorMessage = "File could not be loaded";
+                    ErrorMessage = e.Message;
                 }
             }
         }

--- a/Runtime/Scripts/GltfAsset.cs
+++ b/Runtime/Scripts/GltfAsset.cs
@@ -104,8 +104,15 @@ namespace GLTFast
         {
             if (loadOnStartup && !string.IsNullOrEmpty(url))
             {
-                // Automatic load on startup
-                await Load(FullUrl);
+                try
+                {
+                    // Automatic load on startup
+                    await Load(FullUrl);
+                }
+                catch (NullReferenceException e)
+                {
+                    Debug.LogError("Cannot load file " + url);
+                }
             }
         }
 

--- a/Runtime/Scripts/GltfAsset.cs
+++ b/Runtime/Scripts/GltfAsset.cs
@@ -62,6 +62,16 @@ namespace GLTFast
             set => instantiationSettings = value;
         }
 
+        /// <summary>
+        /// If true, there was an error during load of the glb.
+        /// </summary
+        public bool Error { get; private set; }
+
+        /// <summary>
+        /// If <see cref="Error"/> is true, this can contain an additional error message.
+        /// </summary
+        public string ErrorMessage { get; private set; }
+
         [SerializeField]
         [Tooltip("URL to load the glTF from. Loading local file paths works by prefixing them with \"file://\"")]
         string url;
@@ -112,6 +122,8 @@ namespace GLTFast
                 }
                 catch (NullReferenceException e)
                 {
+                    Error = true;
+                    ErrorMessage = "File could not be loaded";
                     Debug.LogError("Cannot load file " + url);
                 }
             }

--- a/Runtime/Scripts/GltfAsset.cs
+++ b/Runtime/Scripts/GltfAsset.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2023 Unity Technologies and the glTFast authors
 // SPDX-License-Identifier: Apache-2.0
 
+using System;
 using System.IO;
 using System.Threading.Tasks;
 using UnityEngine;
@@ -104,8 +105,15 @@ namespace GLTFast
         {
             if (loadOnStartup && !string.IsNullOrEmpty(url))
             {
-                // Automatic load on startup
-                await Load(FullUrl);
+                try
+                {
+                    // Automatic load on startup
+                    await Load(FullUrl);
+                }
+                catch (NullReferenceException e)
+                {
+                    Debug.LogError("Cannot load file " + url);
+                }
             }
         }
 

--- a/Runtime/Scripts/GltfAsset.cs
+++ b/Runtime/Scripts/GltfAsset.cs
@@ -124,7 +124,6 @@ namespace GLTFast
                 {
                     Error = true;
                     ErrorMessage = "File could not be loaded";
-                    Debug.LogError("Cannot load file " + url);
                 }
             }
         }


### PR DESCRIPTION
Add a check in the start method of the gltf asset, so we can check if an error occurred during import. 